### PR TITLE
Add permanent 301 redirects for legacy 404 tool URLs

### DIFF
--- a/scripts/redirects.cjs
+++ b/scripts/redirects.cjs
@@ -1,1 +1,95 @@
-module.exports.toolRedirects = [];
+module.exports.toolRedirects = [
+  // Video / audio legacy slugs
+  { source: "/video-editor", destination: "/video-tools", permanent: true },
+  { source: "/video-trimmer", destination: "/video-splitter", permanent: true },
+  { source: "/video-player", destination: "/video", permanent: true },
+  { source: "/video-to-gif", destination: "/video-tools", permanent: true },
+  { source: "/video-compressor", destination: "/video-tools", permanent: true },
+  { source: "/video-converter", destination: "/video-to-audio", permanent: true },
+  { source: "/audio-compressor", destination: "/audio-tools", permanent: true },
+  { source: "/audio-editor", destination: "/audio-tools", permanent: true },
+  { source: "/audio-trimmer", destination: "/audio-splitter", permanent: true },
+  { source: "/audio-converter", destination: "/audio-tools", permanent: true },
+  { source: "/voice-recorder", destination: "/audio-tools", permanent: true },
+  { source: "/screen-recorder", destination: "/video-tools", permanent: true },
+
+  // Image / design legacy slugs
+  { source: "/image-editor", destination: "/image-tools", permanent: true },
+  { source: "/icon-generator", destination: "/image-to-icon", permanent: true },
+  {
+    source: "/social-media-resizer",
+    destination: "/image-resizer",
+    permanent: true,
+  },
+  {
+    source: "/compress-images-online",
+    destination: "/image-compressor",
+    permanent: true,
+  },
+  {
+    source: "/free-image-compressor",
+    destination: "/image-compressor",
+    permanent: true,
+  },
+  { source: "/base64-image", destination: "/base64-to-image-converter", permanent: true },
+
+  // SEO / web utility legacy slugs
+  {
+    source: "/keyword-density",
+    destination: "/keyword-density-checker",
+    permanent: true,
+  },
+  {
+    source: "/google-keyword-research",
+    destination: "/keyword-research-tool",
+    permanent: true,
+  },
+  {
+    source: "/bulk-google-index-checker",
+    destination: "/google-index-checker",
+    permanent: true,
+  },
+  {
+    source: "/meta-tags-generator",
+    destination: "/meta-tag-generator",
+    permanent: true,
+  },
+  {
+    source: "/title-rewrite-checker",
+    destination: "/meta-tag-analyzer",
+    permanent: true,
+  },
+  { source: "/xml-formatter", destination: "/json-formatter", permanent: true },
+  {
+    source: "/xml-sitemap-extractor",
+    destination: "/sitemap-generator",
+    permanent: true,
+  },
+  { source: "/url-encoder", destination: "/url-encode", permanent: true },
+  { source: "/ssl-checker", destination: "/hosting-checker", permanent: true },
+  { source: "/help", destination: "/contact", permanent: true },
+  { source: "/api-docs", destination: "/api-key-tester", permanent: true },
+
+  // Developer / text utility legacy slugs
+  { source: "/api-tester", destination: "/api-key-tester", permanent: true },
+  { source: "/text-formatter", destination: "/text-tools", permanent: true },
+  { source: "/hash-generator", destination: "/md5-generator", permanent: true },
+  { source: "/binary-converter", destination: "/binary-to-text-converter", permanent: true },
+  { source: "/text-diff", destination: "/text-compare", permanent: true },
+  { source: "/html-to-pdf", destination: "/word-to-pdf", permanent: true },
+
+  // Downloader / social legacy slugs
+  {
+    source: "/twitter-downloader",
+    destination: "/twitter-video-downloader",
+    permanent: true,
+  },
+  {
+    source: "/facebook-downloader",
+    destination: "/facebook-video-downloader",
+    permanent: true,
+  },
+
+  // PDF / document legacy slugs
+  { source: "/pdf-rotate", destination: "/pdf-tools", permanent: true },
+];


### PR DESCRIPTION
### Motivation
- Site audit showed many legacy tool pages returning 404, so adding redirects preserves link equity and restores user/crawler access to relevant live pages.

### Description
- Added a `toolRedirects` array in `scripts/redirects.cjs` containing grouped permanent redirect mappings for legacy slugs (video/audio, image, SEO/web, developer/text, downloaders, and PDF).
- Mapped legacy URLs (for example, `/keyword-density` → `/keyword-density-checker` and `/twitter-downloader` → `/twitter-video-downloader`) to the closest canonical routes.
- The `toolRedirects` mapping is intended to be consumed by the existing Next.js config rewrites/redirects logic so the redirects are served at runtime.

### Testing
- Loaded the redirects file with `node -e "const {toolRedirects}=require('./scripts/redirects.cjs'); console.log('redirects:', toolRedirects.length)"` which confirmed the mapping was readable.
- Programmatically verified each redirect destination exists in the `src/app` routes list and reported no missing destinations.
- `npm run -s lint` could not be completed in this environment due to a lint invocation path issue, so lint checks were not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf9120a6f0832b89a5afc5cdf06eea)