### PR TITLE
feat: add lorem ipsum text variations

### DIFF
--- a/src/components/tools/generators/LoremIpsumGeneratorTool.jsx
+++ b/src/components/tools/generators/LoremIpsumGeneratorTool.jsx
@@ -14,144 +14,322 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Textarea } from "@/components/ui/textarea";
 
+const WORD_VARIATIONS = {
+	classic: {
+		label: "Classic Lorem",
+		description: "Traditional placeholder copy",
+		words: [
+			"lorem",
+			"ipsum",
+			"dolor",
+			"sit",
+			"amet",
+			"consectetur",
+			"adipiscing",
+			"elit",
+			"sed",
+			"do",
+			"eiusmod",
+			"tempor",
+			"incididunt",
+			"ut",
+			"labore",
+			"et",
+			"dolore",
+			"magna",
+			"aliqua",
+			"ut",
+			"enim",
+			"ad",
+			"minim",
+			"veniam",
+			"quis",
+			"nostrud",
+			"exercitation",
+			"ullamco",
+			"laboris",
+			"nisi",
+			"ut",
+			"aliquip",
+			"ex",
+			"ea",
+			"commodo",
+			"consequat",
+			"duis",
+			"aute",
+			"irure",
+			"dolor",
+			"in",
+			"reprehenderit",
+			"in",
+			"voluptate",
+			"velit",
+			"esse",
+			"cillum",
+			"dolore",
+			"eu",
+			"fugiat",
+			"nulla",
+			"pariatur",
+			"excepteur",
+			"sint",
+			"occaecat",
+			"cupidatat",
+			"non",
+			"proident",
+			"sunt",
+			"in",
+			"culpa",
+			"qui",
+			"officia",
+			"deserunt",
+			"mollit",
+			"anim",
+			"id",
+			"est",
+			"laborum",
+		],
+	},
+	tech: {
+		label: "Tech Ipsum",
+		description: "Product and engineering filler",
+		words: [
+			"deploy",
+			"cluster",
+			"schema",
+			"runtime",
+			"pipeline",
+			"endpoint",
+			"cache",
+			"token",
+			"payload",
+			"request",
+			"response",
+			"gateway",
+			"service",
+			"module",
+			"adapter",
+			"queue",
+			"event",
+			"worker",
+			"index",
+			"bundle",
+			"latency",
+			"throughput",
+			"session",
+			"component",
+			"interface",
+			"protocol",
+			"webhook",
+			"repository",
+			"commit",
+			"release",
+		],
+	},
+	startup: {
+		label: "Startup Ipsum",
+		description: "Founder-friendly product copy",
+		words: [
+			"launch",
+			"iterate",
+			"market",
+			"growth",
+			"traction",
+			"customer",
+			"segment",
+			"insight",
+			"workflow",
+			"platform",
+			"onboarding",
+			"conversion",
+			"retention",
+			"metrics",
+			"roadmap",
+			"prototype",
+			"validation",
+			"feedback",
+			"ecosystem",
+			"revenue",
+			"strategy",
+			"partnership",
+			"funnel",
+			"experience",
+			"automation",
+			"dashboard",
+			"alignment",
+			"scale",
+			"velocity",
+			"outcome",
+		],
+	},
+	hipster: {
+		label: "Hipster Ipsum",
+		description: "Playful lifestyle placeholder text",
+		words: [
+			"artisan",
+			"pour-over",
+			"vinyl",
+			"bespoke",
+			"succulent",
+			"cold-brew",
+			"denim",
+			"letterpress",
+			"microdose",
+			"craft",
+			"brunch",
+			"polaroid",
+			"fixie",
+			"locavore",
+			"banh-mi",
+			"slow-carb",
+			"organic",
+			"mustache",
+			"kombucha",
+			"chia",
+			"brooklyn",
+			"distillery",
+			"flannel",
+			"wayfarers",
+			"skateboard",
+			"bodega",
+			"taiyaki",
+			"vaporware",
+			"selvage",
+			"turmeric",
+		],
+	},
+	pirate: {
+		label: "Pirate Ipsum",
+		description: "Nautical placeholder text",
+		words: [
+			"ahoy",
+			"matey",
+			"plunder",
+			"cutlass",
+			"anchor",
+			"deck",
+			"harbor",
+			"galley",
+			"crow",
+			"mast",
+			"voyage",
+			"parley",
+			"doubloon",
+			"galleon",
+			"buccaneer",
+			"seafarer",
+			"jolly",
+			"roger",
+			"tide",
+			"rum",
+			"booty",
+			"keelhaul",
+			"maroon",
+			"sail",
+			"swab",
+			"lagoon",
+			"treasure",
+			"cannon",
+			"compass",
+			"island",
+		],
+	},
+};
+
+const VARIATION_OPTIONS = Object.entries(WORD_VARIATIONS).map(
+	([value, config]) => ({
+		value,
+		...config,
+	}),
+);
+
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+
+const DEFAULT_OPTIONS = {
+	count: 3,
+	type: "paragraphs",
+	variation: "classic",
+	startWithLorem: true,
+};
+
+const buildLoremIpsum = ({ count, type, variation, startWithLorem }) => {
+	const selectedWords =
+		WORD_VARIATIONS[variation]?.words ?? WORD_VARIATIONS.classic.words;
+	const shouldStartWithLorem = variation === "classic" && startWithLorem;
+	const result = [];
+
+	if (type === "words") {
+		for (let i = 0; i < count; i++) {
+			result.push(selectedWords[i % selectedWords.length]);
+		}
+		let text = result.join(" ");
+		if (shouldStartWithLorem && !text.toLowerCase().startsWith("lorem ipsum")) {
+			text = `Lorem ipsum ${text}`;
+		}
+		return `${capitalize(text)}.`;
+	}
+
+	const sentencesPerPara = 5;
+	const numSentences = type === "sentences" ? count : count * sentencesPerPara;
+
+	const sentences = [];
+	for (let i = 0; i < numSentences; i++) {
+		const sentenceLength = Math.floor(Math.random() * 10) + 5;
+		const sentenceWords = [];
+		for (let j = 0; j < sentenceLength; j++) {
+			const word =
+				selectedWords[Math.floor(Math.random() * selectedWords.length)];
+			sentenceWords.push(word);
+		}
+		const sentenceStr = `${capitalize(sentenceWords.join(" "))}.`;
+		sentences.push(sentenceStr);
+	}
+
+	if (type === "sentences") {
+		let text = sentences.join(" ");
+		if (shouldStartWithLorem && !text.toLowerCase().startsWith("lorem ipsum")) {
+			// Force replace first two words
+			text = `Lorem ipsum ${text.split(" ").slice(2).join(" ")}`;
+		}
+		return text;
+	}
+
+	const paras = [];
+	for (let i = 0; i < sentences.length; i += sentencesPerPara) {
+		paras.push(sentences.slice(i, i + sentencesPerPara).join(" "));
+	}
+	let text = paras.join("\n\n");
+	if (shouldStartWithLorem && !text.toLowerCase().startsWith("lorem ipsum")) {
+		text = `Lorem ipsum ${text.split(" ").slice(2).join(" ")}`;
+	}
+	return text;
+};
+
 export default function LoremIpsumGeneratorTool() {
-	const [count, setCount] = useState(3);
-	const [type, setType] = useState("paragraphs"); // paragraphs, sentences, words
-	const [startWithLorem, setStartWithLorem] = useState(true);
-	const [generatedText, setGeneratedText] = useState("");
+	const [options, setOptions] = useState(DEFAULT_OPTIONS);
+	const [generatedText, setGeneratedText] = useState(() =>
+		buildLoremIpsum(DEFAULT_OPTIONS),
+	);
 
-	const loremWords = [
-		"lorem",
-		"ipsum",
-		"dolor",
-		"sit",
-		"amet",
-		"consectetur",
-		"adipiscing",
-		"elit",
-		"sed",
-		"do",
-		"eiusmod",
-		"tempor",
-		"incididunt",
-		"ut",
-		"labore",
-		"et",
-		"dolore",
-		"magna",
-		"aliqua",
-		"ut",
-		"enim",
-		"ad",
-		"minim",
-		"veniam",
-		"quis",
-		"nostrud",
-		"exercitation",
-		"ullamco",
-		"laboris",
-		"nisi",
-		"ut",
-		"aliquip",
-		"ex",
-		"ea",
-		"commodo",
-		"consequat",
-		"duis",
-		"aute",
-		"irure",
-		"dolor",
-		"in",
-		"reprehenderit",
-		"in",
-		"voluptate",
-		"velit",
-		"esse",
-		"cillum",
-		"dolore",
-		"eu",
-		"fugiat",
-		"nulla",
-		"pariatur",
-		"excepteur",
-		"sint",
-		"occaecat",
-		"cupidatat",
-		"non",
-		"proident",
-		"sunt",
-		"in",
-		"culpa",
-		"qui",
-		"officia",
-		"deserunt",
-		"mollit",
-		"anim",
-		"id",
-		"est",
-		"laborum",
-	];
+	const { count, type, variation, startWithLorem } = options;
 
-	const generate = () => {
-		const result = [];
-
-		if (type === "words") {
-			for (let i = 0; i < count; i++) {
-				result.push(loremWords[i % loremWords.length]);
-			}
-			let text = result.join(" ");
-			if (startWithLorem && !text.toLowerCase().startsWith("lorem ipsum")) {
-				text = `Lorem ipsum ${text}`;
-			}
-			setGeneratedText(`${capitalize(text)}.`);
-			return;
-		}
-
-		const sentencesPerPara = 5;
-		const numSentences =
-			type === "sentences" ? count : count * sentencesPerPara;
-
-		const sentences = [];
-		for (let i = 0; i < numSentences; i++) {
-			const sentenceLength = Math.floor(Math.random() * 10) + 5;
-			const sentenceWords = [];
-			for (let j = 0; j < sentenceLength; j++) {
-				const word = loremWords[Math.floor(Math.random() * loremWords.length)];
-				sentenceWords.push(word);
-			}
-			const sentenceStr = `${capitalize(sentenceWords.join(" "))}.`;
-			sentences.push(sentenceStr);
-		}
-
-		if (type === "sentences") {
-			let text = sentences.join(" ");
-			if (startWithLorem && !text.toLowerCase().startsWith("lorem ipsum")) {
-				// Force replace first two words
-				text = `Lorem ipsum ${text.split(" ").slice(2).join(" ")}`;
-			}
-			setGeneratedText(text);
-		} else {
-			// Paragraphs
-			const paras = [];
-			for (let i = 0; i < sentences.length; i += sentencesPerPara) {
-				paras.push(sentences.slice(i, i + sentencesPerPara).join(" "));
-			}
-			let text = paras.join("\n\n");
-			if (startWithLorem && !text.toLowerCase().startsWith("lorem ipsum")) {
-				text = `Lorem ipsum ${text.split(" ").slice(2).join(" ")}`;
-			}
-			setGeneratedText(text);
-		}
+	const updateOptions = (nextOptions) => {
+		setOptions(nextOptions);
+		setGeneratedText(buildLoremIpsum(nextOptions));
 	};
 
-	const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
-
-	React.useEffect(() => {
-		generate();
-	}, [generate]);
+	const generate = React.useCallback(() => {
+		setGeneratedText(buildLoremIpsum(options));
+	}, [options]);
 
 	const copyToClipboard = () => {
 		if (!generatedText) return;
@@ -172,13 +350,15 @@ export default function LoremIpsumGeneratorTool() {
 			</CardHeader>
 			<CardContent className="p-6 space-y-6">
 				{/* Controls */}
-				<div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+				<div className="grid grid-cols-1 md:grid-cols-3 gap-8">
 					<div className="space-y-4">
 						<Label className="text-base font-semibold">Generate</Label>
 						<RadioGroup
 							defaultValue="paragraphs"
 							value={type}
-							onValueChange={setType}
+							onValueChange={(nextType) =>
+								updateOptions({ ...options, type: nextType })
+							}
 							className="flex flex-col space-y-2"
 						>
 							<div className="flex items-center space-x-2">
@@ -196,12 +376,38 @@ export default function LoremIpsumGeneratorTool() {
 						</RadioGroup>
 					</div>
 
+					<div className="space-y-4">
+						<Label className="text-base font-semibold">Style</Label>
+						<Select
+							value={variation}
+							onValueChange={(nextVariation) =>
+								updateOptions({ ...options, variation: nextVariation })
+							}
+						>
+							<SelectTrigger className="w-full">
+								<span>{WORD_VARIATIONS[variation].label}</span>
+							</SelectTrigger>
+							<SelectContent>
+								{VARIATION_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<p className="text-sm text-muted-foreground">
+							{WORD_VARIATIONS[variation].description}
+						</p>
+					</div>
+
 					<div className="space-y-6">
 						<div className="space-y-4">
 							<Label className="text-base font-semibold">Count: {count}</Label>
 							<Slider
 								value={[count]}
-								onValueChange={(val) => setCount(val[0])}
+								onValueChange={(val) =>
+									updateOptions({ ...options, count: val[0] })
+								}
 								min={1}
 								max={type === "words" ? 100 : 20}
 								step={1}
@@ -212,7 +418,13 @@ export default function LoremIpsumGeneratorTool() {
 							<Checkbox
 								id="startLorem"
 								checked={startWithLorem}
-								onCheckedChange={setStartWithLorem}
+								onCheckedChange={(checked) =>
+									updateOptions({
+										...options,
+										startWithLorem: Boolean(checked),
+									})
+								}
+								disabled={variation !== "classic"}
 							/>
 							<Label htmlFor="startLorem">Start with "Lorem ipsum..."</Label>
 						</div>
@@ -221,13 +433,22 @@ export default function LoremIpsumGeneratorTool() {
 
 				{/* Output */}
 				<div className="space-y-3 pt-6 border-t">
-					<div className="flex justify-between items-center">
+					<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 						<h3 className="text-lg font-semibold">Generated Text</h3>
-						<div className="flex gap-2">
-							<Button variant="outline" size="sm" onClick={generate}>
+						<div className="grid grid-cols-2 gap-2 sm:flex">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={generate}
+								className="w-full sm:w-auto"
+							>
 								<RefreshCw className="mr-2 h-4 w-4" /> Regenerate
 							</Button>
-							<Button onClick={copyToClipboard} size="sm">
+							<Button
+								onClick={copyToClipboard}
+								size="sm"
+								className="w-full sm:w-auto"
+							>
 								<Copy className="mr-2 h-4 w-4" /> Copy Text
 							</Button>
 						</div>

--- a/src/components/tools/generators/LoremIpsumGeneratorTool.jsx
+++ b/src/components/tools/generators/LoremIpsumGeneratorTool.jsx
@@ -261,7 +261,18 @@ const DEFAULT_OPTIONS = {
 	startWithLorem: true,
 };
 
-const buildLoremIpsum = ({ count, type, variation, startWithLorem }) => {
+const createSeededRandom = (initialSeed = 1) => {
+	let seed = initialSeed;
+	return () => {
+		seed = (seed * 1664525 + 1013904223) % 4294967296;
+		return seed / 4294967296;
+	};
+};
+
+const buildLoremIpsum = (
+	{ count, type, variation, startWithLorem },
+	random = Math.random,
+) => {
 	const selectedWords =
 		WORD_VARIATIONS[variation]?.words ?? WORD_VARIATIONS.classic.words;
 	const shouldStartWithLorem = variation === "classic" && startWithLorem;
@@ -283,11 +294,10 @@ const buildLoremIpsum = ({ count, type, variation, startWithLorem }) => {
 
 	const sentences = [];
 	for (let i = 0; i < numSentences; i++) {
-		const sentenceLength = Math.floor(Math.random() * 10) + 5;
+		const sentenceLength = Math.floor(random() * 10) + 5;
 		const sentenceWords = [];
 		for (let j = 0; j < sentenceLength; j++) {
-			const word =
-				selectedWords[Math.floor(Math.random() * selectedWords.length)];
+			const word = selectedWords[Math.floor(random() * selectedWords.length)];
 			sentenceWords.push(word);
 		}
 		const sentenceStr = `${capitalize(sentenceWords.join(" "))}.`;
@@ -317,7 +327,7 @@ const buildLoremIpsum = ({ count, type, variation, startWithLorem }) => {
 export default function LoremIpsumGeneratorTool() {
 	const [options, setOptions] = useState(DEFAULT_OPTIONS);
 	const [generatedText, setGeneratedText] = useState(() =>
-		buildLoremIpsum(DEFAULT_OPTIONS),
+		buildLoremIpsum(DEFAULT_OPTIONS, createSeededRandom()),
 	);
 
 	const { count, type, variation, startWithLorem } = options;


### PR DESCRIPTION
## Summary

- Add style variations to the Lorem Ipsum generator: Classic, Tech, Startup, Hipster, and Pirate
- Keep the classic `Start with "Lorem ipsum..."` behavior scoped to the Classic style
- Refactor generation into a pure helper so option changes regenerate text without a state update inside `useEffect`
- Improve the mobile output header so the regenerate/copy buttons do not overflow narrow screens

Part of #55.

## Checks

- `npx eslint src/components/tools/generators/LoremIpsumGeneratorTool.jsx`
- `npm run typecheck`
- `git diff --check`
- Verified `/lorem-ipsum` locally on the dev server with desktop and mobile Chrome headless screenshots